### PR TITLE
Use default avatar for the user if their Twitter profile pic 404s

### DIFF
--- a/frontend/components/User.tsx
+++ b/frontend/components/User.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import Image from "next/image";
 import { parseUSD } from "utils/usd";
 import { Button } from "./ui/button";
 import { truncateAddress } from "utils";
@@ -24,7 +26,8 @@ export default function User({
     Global.useContainer();
 
   // Profile image
-  const image: string = data.twitterPfpUrl ?? "/rasters/default.png";
+  const fallbackImage = "/rasters/default.png";
+  const [image, setImage] = useState(data.twitterPfpUrl ?? fallbackImage);
   const alt: string = data.twitterUsername
     ? `@${data.twitterUsername} profile picture`
     : `${data.address} profile picture`;
@@ -51,11 +54,12 @@ export default function User({
       <div className="p-2 flex flex-row items-center justify-between w-full">
         {/* Top left (image, handle, address) */}
         <div className="flex items-center">
-          <img
+          <Image
             src={image}
             alt={alt}
             width={30}
             height={30}
+            onError={() => setImage(fallbackImage)}
             className="rounded-md"
           />
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,6 +6,15 @@ const nextConfig = {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'pbs.twimg.com',
+        pathname: '/profile_images/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Some of the Twitter profile picture links stored by FT are invalid ([@HsakaTrades example](https://friendmex.com/?address=0xef42b587e4a3d33f88fa499be1d80c676ff7a226)) - this PR handles that by using the default avatar as a fallback.