### PR TITLE
Use tabular-nums for card update time

### DIFF
--- a/frontend/components/Card.tsx
+++ b/frontend/components/Card.tsx
@@ -28,7 +28,7 @@ export default function Card({
 
         {/* Card header: right */}
         {updated && (
-          <span className="text-zinc-500 text-xs font-light pr-2">
+          <span className="text-zinc-500 text-xs font-light pr-2 tabular-nums">
             {updated}
           </span>
         )}


### PR DESCRIPTION
The text doesn't jump around when numbers change

![2023-08-22 21 30 56](https://github.com/Anish-Agnihotri/friendmex/assets/93895766/dd490cde-7b04-44e2-9e35-58cd0387f347)
