### PR TITLE
Profile sync error handling: Detecting off platform users

### DIFF
--- a/indexer/src/profile.ts
+++ b/indexer/src/profile.ts
@@ -76,12 +76,46 @@ export default class Profile {
 
       // Log user
       logger.info(`Profile: collected @${data.twitterUsername}: ${address}`);
-    } catch {
+    } catch (e: any) {
+      // Detect if address is not an official friendtech user 
+      if (e.response 
+          && e.response.status == 404 
+          && e.response.data 
+          && e.response.data.message === 'Address/User not found.'
+        )
+      {
+        await this.syncOffPlatformUser(address);
+        return;
+      }
       // Timeout for a few seconds, exponential backoff
       this.timeout *= 2;
       await sleep(this.timeout);
       logger.error(
         `Error on profile collection, sleeping for ${this.timeout / 1000}s`
+      );
+    }
+  }
+
+  /**
+   * Syncs users who trade using unregistered friend.tech addresses
+   * @param address
+   */
+  async syncOffPlatformUser(address: string) {
+    try { 
+      await this.db.user.update({
+        where: {
+          address,
+        },
+        data: {
+          twitterUsername: '',
+          twitterPfpUrl: '',
+          profileChecked: true,
+        },
+      });
+      logger.info(`Profile: collected Off Platform User : ${address}`);
+    } catch {
+      logger.error(
+        `Error on off platform profile collection`
       );
     }
   }


### PR DESCRIPTION
Greater than 20% of addresses that trade friend.tech keys are not registered with friend.tech as users thus have no metadata.  These users will always return 404 errors when attempting to be synced by the indexer. This PR should significantly improve the performance of profile sync by decreasing the amount of requests to get metadata for these off platform accounts. 

This PR Adds error handling for the case:  404  'Address/User not found.' then updates the user accordingly.  This will prevent unnecessary db reads and sleep times for a request that will always throw an error. This should also allow the indexer to populate new users metadata quicker.